### PR TITLE
Fix `mismatched-new-delete` compilation error

### DIFF
--- a/include/simple_http.h
+++ b/include/simple_http.h
@@ -1562,7 +1562,7 @@ class HttpServer final
     }
 
     asio::awaitable<void> session(auto socket,
-                                  const std::shared_ptr<asio::io_context> &ctx)
+                                  std::shared_ptr<asio::io_context> ctx)
     {
         auto http1_ch = std::make_shared<Http1Channel>(*ctx, CHANNEL_SIZE);
         auto h2p = std::make_shared<Http2Parse>(nullptr,


### PR DESCRIPTION
```
error: /home/xxx/.xmake/packages/b/boost/1.89.0/f01dd2702c984d5e9899d7a7c7be0d6d/include/boost/asio/detail/memory.hpp:143:12error: ‘void free(void*)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
  143 |   std::free(ptr);
      |   ~~~~~~~~~^~~~~
In file included from modules/playground/src/ne_server.cpp:2:
/home/xxx/.xmake/packages/s/simple_http/v0.4.0/d23a2d9dc9e74cba9854f0128546292a/include/simple_http.h: In member function ‘boost::asio::awaitable<void> simple_http::HttpServer::session(auto:77, const std::shared_ptr<boost::asio::io_context>&) [with auto:77 = std::shared_ptr<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >]’:
/home/xxx/.xmake/packages/s/simple_http/v0.4.0/d23a2d9dc9e74cba9854f0128546292a/include/simple_http.h:1238:25: note: returned from ‘static void* boost::asio::detail::awaitable_frame_base<Executor>::operator new(std::size_t) [with Executor = boost::asio::any_io_executor]’
 1238 |   asio::awaitable<void> session(auto socket,
      |                         ^~~~~~~
In function ‘void boost::asio::aligned_delete(void*)’,
    inlined from ‘static void boost::asio::detail::thread_info_base::deallocate(Purpose, boost::asio::detail::thread_info_base*, void*, std::size_t) [with Purpose = awaitable_frame_tag]’ at /home/xxx/.xmake/packages/b/boost/1.89.0/f01dd2702c984d5e9899d7a7c7be0d6d/include/boost/asio/detail/thread_info_base.hpp:204:19,
    inlined from ‘static void boost::asio::detail::awaitable_frame_base<Executor>::operator delete(void*, std::size_t) [with Executor = boost::asio::any_io_executor]’ at /home/xxx/.xmake/packages/b/boost/1.89.0/f01dd2702c984d5e9899d7a7c7be0d6d/include/boost/asio/impl/awaitable.hpp:110:54,
    inlined from ‘boost::asio::awaitable<void> simple_http::HttpServer::session(auto:77, const std::shared_ptr<boost::asio::io_context>&) [with auto:77 = std::shared_ptr<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> > >’ at /home/xxx/.xmake/packages/s/simple_http/v0.4.0/d23a2d9dc9e74cba9854f0128546292a/include/simple_http.h:1238:25:
/home/xxx/.xmake/packages/b/boost/1.89.0/f01dd2702c984d5e9899d7a7c7be0d6d/include/boost/asio/detail/memory.hpp:143:12: error: ‘void free(void*)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
  143 |   std::free(ptr);
      |   ~~~~~~~~~^~~~~
/home/xxx/.xmake/packages/s/simple_http/v0.4.0/d23a2d9dc9e74cba9854f0128546292a/include/simple_http.h: In member function ‘boost::asio::awaitable<void> simple_http::HttpServer::session(auto:77, const std::shared_ptr<boost::asio::io_context>&) [with auto:77 = std::shared_ptr<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp> > >]’:
/home/xxx/.xmake/packages/s/simple_http/v0.4.0/d23a2d9dc9e74cba9854f0128546292a/include/simple_http.h:1238:25: note: returned from ‘static void* boost::asio::detail::awaitable_frame_base<Executor>::operator new(std::size_t) [with Executor = boost::asio::any_io_executor]’
  > in modules/playground/src/ne_server.cpp
```

Might honestly be a false positive, but this change fixed it nonetheless. Basing this of `cppcoreguidelines-avoid-reference-coroutine-parameters`.