### PR TITLE
Fix breaking changes with boost 1.90

### DIFF
--- a/include/simple_http.h
+++ b/include/simple_http.h
@@ -1623,7 +1623,10 @@ class HttpServer final
         if (headers.find(http::field::upgrade) != headers.end() &&
             headers[http::field::upgrade] == "h2c")
         {
-            h2_setting = headers[http::field::http2_settings];
+            constexpr auto http2_header = "HTTP2-Settings";
+            if (headers.contains(http2_header)) {
+                h2_setting = headers.at(http2_header);
+            }
         }
 
         std::tie(ec, bytes) = co_await http::async_read(


### PR DESCRIPTION
Replace boost `http::field::http2_settings` with hand-coded "HTTP2-Settings". Non-standard header fields were removed in 1.90, http2_settings included.

[boost_pr]: https://github.com/boostorg/beast/pull/3042